### PR TITLE
Add support for search/bytitle and podcasts/byguid

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Using Promise
         -   `custom(path: String, queries: Object)`
 -   Search
     -   `searchByTerm(q: String, val: String, clean: Boolean, fullText: Boolean)`
+    -   `searchByTitle(q: String, val: String, clean: Boolean, fullText: Boolean)`
     -   `searchEpisodesByPerson(q: String, fullText: Boolean)`
 -   Podcasts
     -   `podcastsByFeedUrl(feedUrl: String)`
     -   `podcastsByFeedId(feedId: Number)`
     -   `podcastsByFeedItunesId(itunesId: Number)`
+    -   `podcastsByGUID(guid: Number)`
     -   `podcastsByTag()`
     -   `podcastsTrending(max: Number, since: Number, lang: String, cat: String, notcat: String)`
     -   `podcastsDead()`
@@ -66,12 +68,11 @@ Using Promise
 -   Value
     -   `valueByFeedUrl(feedUrl: String)`
     -   `valueByFeedId(feedId: Number)`
--   Stats
-    -   `statsCurrent()`
 -   Categories
     -   `categoriesList()`
 -   Notify Hub
-    -   `hubPubNotify(feedId: Number, update: Boolean)`
+    -   `hubPubNotifyById(feedId: Number)`
+    -   `hubPubNotifyByUrl(feedUrl: string)`
 -   Add
     -   `addByFeedUrl(feedUrl: String, chash: String, itunesId: Number)`
     -   `addByItunesId(itunesId: Number)`

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const querystring = require('querystring')
 const BASE_API_URL = 'https://api.podcastindex.org/api/1.0/'
 
 const PATH_SEARCH_BY_TERM = 'search/byterm'
+const PATH_SEARCH_BY_TITLE = 'search/bytitle'
 const PATH_SEARCH_EPISODE_BY_PERSON = 'search/byperson'
 const PATH_ADD_BY_FEED_URL = 'add/byfeedurl'
 const PATH_ADD_BY_ITUNES_ID = 'add/byitunesid'
@@ -20,6 +21,7 @@ const PATH_EPISODES_RANDOM = 'episodes/random'
 const PATH_PODCASTS_BY_FEED_URL = 'podcasts/byfeedurl'
 const PATH_PODCASTS_BY_FEED_ID = 'podcasts/byfeedid'
 const PATH_PODCASTS_BY_ITUNES_ID = 'podcasts/byitunesid'
+const PATH_PODCASTS_BY_GUID = 'podcasts/byguid'
 const PATH_PODCASTS_BY_TAG = 'podcasts/bytag'
 const PATH_PODCASTS_TRENDING = 'podcasts/trending'
 const PATH_PODCASTS_DEAD = 'podcasts/dead'
@@ -29,7 +31,6 @@ const PATH_RECENT_NEWFEEDS = 'recent/newfeeds'
 const PATH_RECENT_SOUNDBITES = 'recent/soundbites'
 const PATH_VALUE_BY_FEED_ID = 'value/byfeedid'
 const PATH_VALUE_BY_FEED_URL = 'value/byfeedurl'
-const PATH_STATS_CURRENT = 'stats/current'
 const PATH_CATEGORIES_LIST = 'categories/list'
 const PATH_HUB_PUBNOTIFIY = 'hub/pubnotify'
 
@@ -103,6 +104,15 @@ module.exports = (key, secret, userAgent) => {
             if (fullText) queries['fullText'] = ''
             return custom(PATH_SEARCH_BY_TERM, queries)
         },
+        searchByTitle: async (q, val = '', clean = false, fullText = false) => {
+            let queries = {
+                q: q,
+            }
+            if (val !== '') queries['val'] = val
+            if (clean) queries['clean'] = ''
+            if (fullText) queries['fullText'] = ''
+            return custom(PATH_SEARCH_BY_TITLE, queries)
+        },
         searchEpisodesByPerson: async (q, fullText = false) => {
             let queries = {
                 q: q,
@@ -119,6 +129,9 @@ module.exports = (key, secret, userAgent) => {
         },
         podcastsByFeedItunesId: async (itunesId) => {
             return custom(PATH_PODCASTS_BY_ITUNES_ID, { id: itunesId })
+        },
+        podcastsByGUID: async (guid) => {
+            return custom(PATH_PODCASTS_BY_GUID, { guid: guid })
         },
         podcastsByTag: async () => {
             return custom(PATH_PODCASTS_BY_TAG, { 'podcast-value': '' })
@@ -271,19 +284,20 @@ module.exports = (key, secret, userAgent) => {
             })
         },
 
-        statsCurrent: async () => {
-            return custom(PATH_STATS_CURRENT)
-        },
-
         categoriesList: async () => {
             return custom(PATH_CATEGORIES_LIST)
         },
 
-        hubPubNotify: async (feedId, update = true) => {
+        hubPubNotifyById: async (feedId) => {
             let queries = {
                 id: feedId,
             }
-            if (update) queries['update'] = ''
+            return custom(PATH_HUB_PUBNOTIFIY, queries)
+        },
+        hubPubNotifyByUrl: async (feedUrl) => {
+            let queries = {
+                url: feedUrl,
+            }
             return custom(PATH_HUB_PUBNOTIFIY, queries)
         },
     }

--- a/test/api.js
+++ b/test/api.js
@@ -7,7 +7,7 @@ const api = lib(
 )
 const apiBadCreds = lib('ABC', '123')
 
-const SEARCH_TERM = 'Joe Rogan Experience'
+const SEARCH_TERM = 'The Joe Rogan Experience'
 const SEARCH_PERSON = 'Joe Rogan'
 const FEED_ID = 550168
 const FEED_ID_VALUE = 920666
@@ -20,6 +20,7 @@ const EPISODE_ID = 16795090
 const RECENT_FEEDS_COUNT = 3
 const RECENT_EPISODES_COUNT = 3
 const RECENT_EPISODES_EXCLUDE = 'news'
+const FEED_GUID = '9d783600-a77f-5c77-9042-0d9f3280465e'
 
 it('Requires API credentials', () => {
     expect(() => {
@@ -71,6 +72,17 @@ it('Search by term (value)', async () => {
     expect(results).toHaveProperty('feeds')
     // expect(results.feeds[0].id).toEqual(FEED_ID)
     // expect(results.feeds[0].title).toEqual(FEED_TITLE)
+})
+
+it('Search by title', async () => {
+    expect.assertions(6)
+    const results = await api.searchByTitle(FEED_TITLE)
+    expect(results.status).toEqual('true')
+    expect(results.feeds.length).toBeGreaterThan(0)
+    expect(results).toHaveProperty('query', FEED_TITLE)
+    expect(results).toHaveProperty('feeds')
+    expect(results.feeds[0].id).toEqual(FEED_ID)
+    expect(results.feeds[0].title).toEqual(FEED_TITLE)
 })
 
 it('Search episodes by person', async () => {
@@ -164,6 +176,14 @@ it('Podcasts By Feed iTunes ID', async () => {
     expect.assertions(3)
     const results = await api.podcastsByFeedItunesId(FEED_ITUNES_ID)
     expect(results).toHaveProperty('query.id', FEED_ITUNES_ID.toString())
+    expect(results.feed.id).toEqual(FEED_ID)
+    expect(results.feed.itunesId).toEqual(FEED_ITUNES_ID)
+})
+
+it('Podcasts By GUID', async () => {
+    expect.assertions(3)
+    const results = await api.podcastsByGUID(FEED_GUID)
+    expect(results).toHaveProperty('query.id', FEED_ID)
     expect(results.feed.id).toEqual(FEED_ID)
     expect(results.feed.itunesId).toEqual(FEED_ITUNES_ID)
 })
@@ -265,13 +285,6 @@ it('Value By Feed ID', async () => {
     const results = await api.valueByFeedId(FEED_ID_VALUE)
     expect(results).toHaveProperty('query.id', FEED_ID_VALUE.toString())
     expect(results).toHaveProperty('value')
-})
-
-it('Stats Current', async () => {
-    expect.assertions(2)
-    const results = await api.statsCurrent()
-    expect(results).toHaveProperty('status', 'true')
-    expect(results.stats).toHaveProperty('feedCountTotal')
 })
 
 it('Categories list', async () => {


### PR DESCRIPTION
Remove stats/current since it is no longer supported by the API.

Change hubPubNotify to hubPubNotifyById and add hubPubNotifyByUrl. Remove update argument from hubPubNotify calls since it is no longer supported by the API.